### PR TITLE
feat(fase-2): assistente AI Ollama

### DIFF
--- a/backend/api/v1/chat.py
+++ b/backend/api/v1/chat.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from backend.core.rate_limit import check_rate_limit
+from backend.services.ai_service import OllamaError, ask
+
+router = APIRouter(prefix="/v1/chat", tags=["chat"])
+
+
+class ChatRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=1000)
+    procedure_slug: str | None = None
+
+
+class ChatResponse(BaseModel):
+    reply: str
+
+
+@router.post("", response_model=ChatResponse)
+async def chat(request: Request, body: ChatRequest) -> ChatResponse:
+    client_ip = request.client.host if request.client else "unknown"
+    if not check_rate_limit(client_ip):
+        raise HTTPException(status_code=429, detail="Troppe richieste. Riprova tra un minuto.")
+
+    try:
+        reply = await ask(body.message, body.procedure_slug)
+    except OllamaError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return ChatResponse(reply=reply)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -8,7 +8,7 @@ class Settings(BaseSettings):
     ollama_base_url: str
     ollama_model: str
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 
 settings = Settings()

--- a/backend/core/rate_limit.py
+++ b/backend/core/rate_limit.py
@@ -1,0 +1,17 @@
+import time
+from collections import defaultdict
+
+_windows: dict[str, list[float]] = defaultdict(list)
+
+LIMIT = 10   # max requests per window
+WINDOW = 60  # window size in seconds
+
+
+def check_rate_limit(key: str) -> bool:
+    """Return True if the request is allowed, False if rate-limited."""
+    now = time.time()
+    _windows[key] = [t for t in _windows[key] if now - t < WINDOW]
+    if len(_windows[key]) >= LIMIT:
+        return False
+    _windows[key].append(now)
+    return True

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 
+from backend.api.v1.chat import router as chat_router
 from backend.api.v1.procedures import router as procedures_router
 
 app = FastAPI(title="Navigatore Burocratico API")
 
 app.include_router(procedures_router)
+app.include_router(chat_router)
 
 
 @app.get("/health")

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -1,0 +1,73 @@
+import httpx
+
+from backend.core.config import settings
+from backend.services.procedure_service import ProcedureNotFound, get_procedure
+
+_SYSTEM_PROMPT = """Sei un assistente specializzato nelle procedure burocratiche italiane, \
+per la Provincia di Cosenza, Regione Calabria.
+
+Rispondi in modo chiaro e conciso. Rispondi SOLO a domande relative a burocrazia, \
+documenti necessari, uffici competenti, scadenze, costi e iter amministrativi.
+
+Se non sei certo di un'informazione, dì esplicitamente che non ne sei sicuro e invita \
+il cittadino a verificare direttamente presso l'ufficio competente o il sito istituzionale. \
+Non inventare mai dati normativi, importi o requisiti specifici.
+
+Rispondi sempre in italiano."""
+
+
+class OllamaError(Exception):
+    pass
+
+
+async def _call_ollama(payload: dict) -> dict:
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        try:
+            response = await client.post(
+                f"{settings.ollama_base_url}/api/chat",
+                json=payload,
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.ConnectError as exc:
+            raise OllamaError("Servizio AI non disponibile al momento.") from exc
+        except httpx.TimeoutException as exc:
+            raise OllamaError("Il servizio AI ha impiegato troppo tempo a rispondere.") from exc
+        except httpx.HTTPStatusError as exc:
+            raise OllamaError(
+                f"Errore dal servizio AI: {exc.response.status_code}"
+            ) from exc
+
+
+def _build_system_prompt(procedure_slug: str | None) -> str:
+    if not procedure_slug:
+        return _SYSTEM_PROMPT
+
+    try:
+        proc = get_procedure(procedure_slug)
+    except ProcedureNotFound:
+        return _SYSTEM_PROMPT
+
+    context = (
+        f"\n\nIl cittadino sta seguendo la procedura: **{proc.name}**\n"
+        f"Descrizione: {proc.description}\n"
+        f"Ente competente: {proc.ente_competente}\n"
+        f"Tempo stimato: {proc.tempo_stimato_giorni} giorni\n"
+        f"Costo stimato: {proc.costo_stimato_eur} €\n\n"
+        f"Usa queste informazioni per rispondere in modo contestuale."
+    )
+    return _SYSTEM_PROMPT + context
+
+
+async def ask(message: str, procedure_slug: str | None = None) -> str:
+    system_prompt = _build_system_prompt(procedure_slug)
+    payload = {
+        "model": settings.ollama_model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": message},
+        ],
+        "stream": False,
+    }
+    data = await _call_ollama(payload)
+    return data["message"]["content"]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.main import app
+
+
+@pytest.fixture
+def client():
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _mock_ollama(reply: str = "Risposta di test."):
+    return patch(
+        "backend.services.ai_service._call_ollama",
+        new=AsyncMock(return_value={"message": {"role": "assistant", "content": reply}}),
+    )
+
+
+async def test_chat_basic(client):
+    with _mock_ollama("Per presentare la SCIA devi..."):
+        async with client as c:
+            response = await c.post("/v1/chat", json={"message": "Come presento la SCIA?"})
+    assert response.status_code == 200
+    assert response.json()["reply"] == "Per presentare la SCIA devi..."
+
+
+async def test_chat_with_procedure_slug(client):
+    with _mock_ollama("La SCIA edilizia richiede...") as mock:
+        async with client as c:
+            response = await c.post(
+                "/v1/chat",
+                json={
+                    "message": "Quali documenti servono?",
+                    "procedure_slug": "scia-edilizia-cosenza",
+                },
+            )
+    assert response.status_code == 200
+    # verify that the system prompt was enriched with procedure context
+    called_payload = mock.call_args[0][0]
+    system_msg = called_payload["messages"][0]["content"]
+    assert "SCIA Edilizia" in system_msg
+
+
+async def test_chat_unknown_procedure_slug(client):
+    """Unknown slug is silently ignored — base system prompt is used."""
+    with _mock_ollama("Non conosco quella procedura."):
+        async with client as c:
+            response = await c.post(
+                "/v1/chat",
+                json={"message": "Cosa devo fare?", "procedure_slug": "procedura-inesistente"},
+            )
+    assert response.status_code == 200
+
+
+async def test_chat_ollama_unavailable(client):
+    from backend.services.ai_service import OllamaError
+
+    with patch(
+        "backend.services.ai_service._call_ollama",
+        new=AsyncMock(side_effect=OllamaError("Servizio AI non disponibile al momento.")),
+    ):
+        async with client as c:
+            response = await c.post("/v1/chat", json={"message": "Test"})
+    assert response.status_code == 503
+    assert "non disponibile" in response.json()["detail"]
+
+
+async def test_chat_rate_limited(client):
+    with patch("backend.api.v1.chat.check_rate_limit", return_value=False):
+        async with client as c:
+            response = await c.post("/v1/chat", json={"message": "Test"})
+    assert response.status_code == 429
+
+
+async def test_chat_empty_message(client):
+    async with client as c:
+        response = await c.post("/v1/chat", json={"message": ""})
+    assert response.status_code == 422
+
+
+async def test_chat_message_too_long(client):
+    async with client as c:
+        response = await c.post("/v1/chat", json={"message": "x" * 1001})
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary

- **`AIService`**: client HTTPX async verso `Ollama /api/chat`; gestisce `ConnectError`, `Timeout`, `HTTPStatusError` → `OllamaError` → HTTP 503
- **Prompt engineering**: system prompt context-aware, arricchito con nome/descrizione/ente/costi della procedura attiva se `procedure_slug` è fornito
- **`POST /v1/chat`**: validazione messaggio (1–1000 char), rate limit 10 req/min per IP in-memory (sliding window, nessuna dipendenza esterna)
- **Fix**: `extra="ignore"` in `config.py` — `POSTGRES_USER`/`POSTGRES_PASSWORD` nel `.env` non causano più errore pydantic-settings

## Note

Ollama non è disponibile in CI — tutti i test mockano `_call_ollama` direttamente. Il servizio è testabile in locale con `docker compose up` e un'istanza Ollama attiva.

## Test plan

- [x] `pytest`: 14/14 passed
- [x] `ruff check .`: no errors
- [x] CI verde su GitHub Actions