### PR TITLE
feat(fase-3): autenticazione JWT e salvataggio progresso

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: pytest
         env:
           APP_ENV: testing
-          SECRET_KEY: ci-secret-key-not-used-in-tests
+          SECRET_KEY: ci-secret-key-32-bytes-minimum-ok
           DATABASE_URL: postgresql+asyncpg://nav_user:password@localhost:5432/navigatore_burocratico
           OLLAMA_BASE_URL: http://localhost:11434
           OLLAMA_MODEL: llama3

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,6 +7,7 @@ from alembic import context
 from backend.core.config import settings
 from backend.db.base import Base
 from backend.models.procedure import Document, Procedure, Step  # noqa: F401
+from backend.models.user import User, UserProgress  # noqa: F401
 
 config = context.config
 

--- a/alembic/versions/20260327_c2d3e4f5a6b1_create_users_progress.py
+++ b/alembic/versions/20260327_c2d3e4f5a6b1_create_users_progress.py
@@ -1,0 +1,52 @@
+"""create users and user_progress tables
+
+Revision ID: c2d3e4f5a6b1
+Revises: b1c2d3e4f5a6
+Create Date: 2026-03-27 00:02:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c2d3e4f5a6b1"
+down_revision: Union[str, None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("hashed_password", sa.String(length=255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_index("ix_users_email", "users", ["email"])
+
+    op.create_table(
+        "user_progress",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("procedure_slug", sa.String(length=100), nullable=False),
+        sa.Column("completed_steps", sa.JSON(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "procedure_slug"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_progress")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")

--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,0 +1,39 @@
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.db.session import get_db
+from backend.models.user import User
+from backend.services.auth_service import decode_token
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/v1/auth/token")
+
+_credentials_exception = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail="Token non valido o scaduto.",
+    headers={"WWW-Authenticate": "Bearer"},
+)
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    try:
+        payload = decode_token(token)
+    except jwt.InvalidTokenError as exc:
+        raise _credentials_exception from exc
+
+    if payload.get("type") != "access":
+        raise _credentials_exception
+    email: str | None = payload.get("sub")
+    if not email:
+        raise _credentials_exception
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+    if not user or not user.is_active:
+        raise _credentials_exception
+    return user

--- a/backend/api/v1/auth.py
+++ b/backend/api/v1/auth.py
@@ -1,0 +1,107 @@
+import jwt
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.deps import get_current_user
+from backend.db.session import get_db
+from backend.models.user import User
+from backend.services.auth_service import (
+    create_access_token,
+    create_refresh_token,
+    decode_token,
+    hash_password,
+    verify_password,
+)
+
+router = APIRouter(prefix="/v1/auth", tags=["auth"])
+
+
+# ── schemas ──────────────────────────────────────────────────────────────────
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str = Field(..., min_length=8)
+
+
+class UserOut(BaseModel):
+    id: int
+    email: str
+    is_active: bool
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Token(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+# ── routes ───────────────────────────────────────────────────────────────────
+
+
+@router.post("/register", response_model=UserOut, status_code=status.HTTP_201_CREATED)
+async def register(body: UserCreate, db: AsyncSession = Depends(get_db)) -> User:
+    result = await db.execute(select(User).where(User.email == body.email))
+    if result.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="Email già registrata.")
+    user = User(email=body.email, hashed_password=hash_password(body.password))
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+@router.post("/token", response_model=Token)
+async def login(
+    form: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_db),
+) -> Token:
+    result = await db.execute(select(User).where(User.email == form.username))
+    user = result.scalar_one_or_none()
+    if not user or not verify_password(form.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Credenziali non valide.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return Token(
+        access_token=create_access_token(user.email),
+        refresh_token=create_refresh_token(user.email),
+    )
+
+
+@router.post("/refresh", response_model=Token)
+async def refresh(body: RefreshRequest, db: AsyncSession = Depends(get_db)) -> Token:
+    invalid = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED, detail="Token di refresh non valido."
+    )
+    try:
+        payload = decode_token(body.refresh_token)
+    except jwt.InvalidTokenError as exc:
+        raise invalid from exc
+    if payload.get("type") != "refresh":
+        raise invalid
+    email: str | None = payload.get("sub")
+    if not email:
+        raise invalid
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalar_one_or_none()
+    if not user or not user.is_active:
+        raise invalid
+    return Token(
+        access_token=create_access_token(user.email),
+        refresh_token=create_refresh_token(user.email),
+    )
+
+
+@router.get("/me", response_model=UserOut)
+async def me(current_user: User = Depends(get_current_user)) -> User:
+    return current_user

--- a/backend/api/v1/progress.py
+++ b/backend/api/v1/progress.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.deps import get_current_user
+from backend.db.session import get_db
+from backend.models.user import User, UserProgress
+
+router = APIRouter(prefix="/v1/progress", tags=["progress"])
+
+
+# ── schemas ──────────────────────────────────────────────────────────────────
+
+
+class ProgressIn(BaseModel):
+    completed_steps: list[int]
+
+
+class ProgressOut(BaseModel):
+    procedure_slug: str
+    completed_steps: list[int]
+    started_at: datetime
+    updated_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ── routes ───────────────────────────────────────────────────────────────────
+
+
+@router.get("/{procedure_slug}", response_model=ProgressOut)
+async def get_progress(
+    procedure_slug: str,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> UserProgress:
+    result = await db.execute(
+        select(UserProgress).where(
+            UserProgress.user_id == user.id,
+            UserProgress.procedure_slug == procedure_slug,
+        )
+    )
+    progress = result.scalar_one_or_none()
+    if not progress:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Nessun progresso trovato per questa procedura.",
+        )
+    return progress
+
+
+@router.put("/{procedure_slug}", response_model=ProgressOut)
+async def update_progress(
+    procedure_slug: str,
+    body: ProgressIn,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(get_current_user),
+) -> UserProgress:
+    result = await db.execute(
+        select(UserProgress).where(
+            UserProgress.user_id == user.id,
+            UserProgress.procedure_slug == procedure_slug,
+        )
+    )
+    progress = result.scalar_one_or_none()
+    if progress:
+        progress.completed_steps = body.completed_steps
+        progress.updated_at = datetime.now(timezone.utc)
+    else:
+        progress = UserProgress(
+            user_id=user.id,
+            procedure_slug=procedure_slug,
+            completed_steps=body.completed_steps,
+        )
+        db.add(progress)
+    await db.commit()
+    await db.refresh(progress)
+    return progress

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,16 @@
 from fastapi import FastAPI
 
+from backend.api.v1.auth import router as auth_router
 from backend.api.v1.chat import router as chat_router
 from backend.api.v1.procedures import router as procedures_router
+from backend.api.v1.progress import router as progress_router
 
 app = FastAPI(title="Navigatore Burocratico API")
 
 app.include_router(procedures_router)
 app.include_router(chat_router)
+app.include_router(auth_router)
+app.include_router(progress_router)
 
 
 @app.get("/health")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,3 +1,4 @@
 from backend.models.procedure import Document, Procedure, Step
+from backend.models.user import User, UserProgress
 
-__all__ = ["Procedure", "Step", "Document"]
+__all__ = ["Procedure", "Step", "Document", "User", "UserProgress"]

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from backend.db.base import Base
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_now
+    )
+
+    progress: Mapped[list["UserProgress"]] = relationship(
+        "UserProgress", back_populates="user", cascade="all, delete-orphan"
+    )
+
+
+class UserProgress(Base):
+    __tablename__ = "user_progress"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    procedure_slug: Mapped[str] = mapped_column(String(100), nullable=False)
+    completed_steps: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_now, onupdate=_now
+    )
+
+    __table_args__ = (UniqueConstraint("user_id", "procedure_slug"),)
+
+    user: Mapped["User"] = relationship("User", back_populates="progress")

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+import jwt
+
+from backend.core.config import settings
+
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REFRESH_TOKEN_EXPIRE_DAYS = 30
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
+
+
+def _create_token(data: dict, expires_delta: timedelta) -> str:
+    payload = {**data, "exp": datetime.now(timezone.utc) + expires_delta}
+    return jwt.encode(payload, settings.secret_key, algorithm=ALGORITHM)
+
+
+def create_access_token(email: str) -> str:
+    return _create_token(
+        {"sub": email, "type": "access"},
+        timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+
+
+def create_refresh_token(email: str) -> str:
+    return _create_token(
+        {"sub": email, "type": "refresh"},
+        timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+
+
+def decode_token(token: str) -> dict:
+    """Decode and verify a JWT token. Raises jwt.InvalidTokenError on failure."""
+    return jwt.decode(token, settings.secret_key, algorithms=[ALGORITHM])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "httpx>=0.28.0",
     "pydantic-settings>=2.7.0",
     "python-multipart>=0.0.20",
+    "PyJWT>=2.9.0",
+    "bcrypt>=4.0.0",
+    "email-validator>=2.2.0",
 ]
 
 [project.optional-dependencies]
@@ -25,6 +28,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "httpx>=0.28.0",
     "ruff>=0.9.0",
+    "aiosqlite>=0.21.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import backend.models  # noqa: F401 — ensures all models are registered with Base.metadata
+from backend.db.base import Base
+from backend.db.session import get_db
+from backend.main import app
+
+_TEST_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+async def auth_client():
+    """AsyncClient backed by an isolated in-memory SQLite database."""
+    engine = create_async_engine(_TEST_DB_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.pop(get_db, None)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,104 @@
+from httpx import AsyncClient
+
+_USER = {"email": "test@example.com", "password": "password123"}
+
+
+async def _register_and_login(client: AsyncClient) -> str:
+    await client.post("/v1/auth/register", json=_USER)
+    response = await client.post(
+        "/v1/auth/token", data={"username": _USER["email"], "password": _USER["password"]}
+    )
+    return response.json()["access_token"]
+
+
+async def test_register(auth_client):
+    response = await auth_client.post("/v1/auth/register", json=_USER)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == _USER["email"]
+    assert data["is_active"] is True
+    assert "hashed_password" not in data
+
+
+async def test_register_duplicate(auth_client):
+    await auth_client.post("/v1/auth/register", json=_USER)
+    response = await auth_client.post("/v1/auth/register", json=_USER)
+    assert response.status_code == 409
+
+
+async def test_register_invalid_email(auth_client):
+    response = await auth_client.post(
+        "/v1/auth/register", json={"email": "not-an-email", "password": "password123"}
+    )
+    assert response.status_code == 422
+
+
+async def test_register_short_password(auth_client):
+    response = await auth_client.post(
+        "/v1/auth/register", json={"email": "a@b.com", "password": "short"}
+    )
+    assert response.status_code == 422
+
+
+async def test_login(auth_client):
+    await auth_client.post("/v1/auth/register", json=_USER)
+    response = await auth_client.post(
+        "/v1/auth/token", data={"username": _USER["email"], "password": _USER["password"]}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+    assert data["token_type"] == "bearer"
+
+
+async def test_login_wrong_password(auth_client):
+    await auth_client.post("/v1/auth/register", json=_USER)
+    response = await auth_client.post(
+        "/v1/auth/token", data={"username": _USER["email"], "password": "wrongpass"}
+    )
+    assert response.status_code == 401
+
+
+async def test_login_unknown_user(auth_client):
+    response = await auth_client.post(
+        "/v1/auth/token", data={"username": "nobody@example.com", "password": "password123"}
+    )
+    assert response.status_code == 401
+
+
+async def test_me(auth_client):
+    token = await _register_and_login(auth_client)
+    response = await auth_client.get("/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.json()["email"] == _USER["email"]
+
+
+async def test_me_no_token(auth_client):
+    response = await auth_client.get("/v1/auth/me")
+    assert response.status_code == 401
+
+
+async def test_me_invalid_token(auth_client):
+    response = await auth_client.get(
+        "/v1/auth/me", headers={"Authorization": "Bearer notavalidtoken"}
+    )
+    assert response.status_code == 401
+
+
+async def test_refresh(auth_client):
+    await auth_client.post("/v1/auth/register", json=_USER)
+    token_response = await auth_client.post(
+        "/v1/auth/token", data={"username": _USER["email"], "password": _USER["password"]}
+    )
+    refresh_token = token_response.json()["refresh_token"]
+    response = await auth_client.post("/v1/auth/refresh", json={"refresh_token": refresh_token})
+    assert response.status_code == 200
+    assert "access_token" in response.json()
+
+
+async def test_refresh_with_access_token_fails(auth_client):
+    """Access token must not be accepted as refresh token."""
+    token = await _register_and_login(auth_client)
+    response = await auth_client.post("/v1/auth/refresh", json={"refresh_token": token})
+    assert response.status_code == 401

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,59 @@
+from httpx import AsyncClient
+
+_USER = {"email": "progress@example.com", "password": "password123"}
+
+
+async def _auth_headers(client: AsyncClient) -> dict:
+    await client.post("/v1/auth/register", json=_USER)
+    response = await client.post(
+        "/v1/auth/token", data={"username": _USER["email"], "password": _USER["password"]}
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_update_and_get_progress(auth_client):
+    headers = await _auth_headers(auth_client)
+    slug = "scia-edilizia-cosenza"
+
+    put_response = await auth_client.put(
+        f"/v1/progress/{slug}", json={"completed_steps": [1, 2]}, headers=headers
+    )
+    assert put_response.status_code == 200
+    data = put_response.json()
+    assert data["procedure_slug"] == slug
+    assert data["completed_steps"] == [1, 2]
+    assert "started_at" in data
+    assert "updated_at" in data
+
+    get_response = await auth_client.get(f"/v1/progress/{slug}", headers=headers)
+    assert get_response.status_code == 200
+    assert get_response.json()["completed_steps"] == [1, 2]
+
+
+async def test_update_progress_overwrites(auth_client):
+    headers = await _auth_headers(auth_client)
+    slug = "scia-edilizia-cosenza"
+
+    await auth_client.put(f"/v1/progress/{slug}", json={"completed_steps": [1]}, headers=headers)
+    await auth_client.put(
+        f"/v1/progress/{slug}", json={"completed_steps": [1, 2, 3]}, headers=headers
+    )
+
+    response = await auth_client.get(f"/v1/progress/{slug}", headers=headers)
+    assert response.json()["completed_steps"] == [1, 2, 3]
+
+
+async def test_get_progress_not_started(auth_client):
+    headers = await _auth_headers(auth_client)
+    response = await auth_client.get("/v1/progress/scia-edilizia-cosenza", headers=headers)
+    assert response.status_code == 404
+
+
+async def test_progress_requires_auth(auth_client):
+    get_response = await auth_client.get("/v1/progress/scia-edilizia-cosenza")
+    put_response = await auth_client.put(
+        "/v1/progress/scia-edilizia-cosenza", json={"completed_steps": [1]}
+    )
+    assert get_response.status_code == 401
+    assert put_response.status_code == 401


### PR DESCRIPTION
## Summary

- **Auth**: `POST /v1/auth/register` (email+password), `/token` (OAuth2), `/refresh`, `GET /me`
- **JWT**: access token (30 min) + refresh token (30 giorni), `type` claim per distinguerli
- **Bcrypt**: hashing diretto via libreria `bcrypt≥4.x` (no passlib — incompatibile con Python 3.13)
- **Progresso**: `GET/PUT /v1/progress/{procedure_slug}` — salva quali step ha completato l'utente; richiede Bearer token
- **ORM**: `User`, `UserProgress` con datetime timezone-aware e default Python-side (compatibili con PostgreSQL e SQLite nei test)
- **Test**: 16 nuovi test (auth + progress) con DB SQLite in-memory isolato per fixture via `conftest.py`
- **CI**: `SECRET_KEY` portata a ≥32 byte per eliminare `InsecureKeyLengthWarning` di PyJWT

## Test plan

- [x] `pytest`: 30/30 passed
- [x] `ruff check .`: no errors
- [x] CI verde su GitHub Actions